### PR TITLE
added Opera 12/Linux

### DIFF
--- a/tests/accesskey-cyrillic-latin-link-manual.html
+++ b/tests/accesskey-cyrillic-latin-link-manual.html
@@ -42,6 +42,7 @@
   <dd class="pass">Firefox exposes "<samp>activation: Alt+Shift+я g</samp>" as a value of the <code>accessKeyLabel</code> DOM attribute</dd>
  <dt class="fail">Epiphany 3.10.3, 64-bit Ubuntu Linux 14.04 on "g"</dt>
  <dt class="fail">Chromium 45, 64-bit Ubuntu Linux 14.04 on "g"</dt>
+ <dt class="fail">Opera 12, 64-bit Ubuntu Linux 14.04 shows accesskey as "("</dt>
  <dt class="fail">Firefox 42, 64-bit Windows 7 on "g"</dt>
  <dt class="fail">Internet Explorer 11, 64-bit Windows 7 on "g"</dt>
  <dt class="fail">Chrome 46, 64-bit Windows 7 on "g"</dt>

--- a/tests/accesskey-cyrillic-latin-manual.html
+++ b/tests/accesskey-cyrillic-latin-manual.html
@@ -43,6 +43,7 @@
  <dt class="fail">Epiphany 3.10.3, 64-bit Ubuntu Linux 14.04 on "g"</dt>
  <dt class="fail">Chromium 45, 64-bit Ubuntu Linux 14.04 on "g"</dt>
  <dt class="fail">Firefox 42, 64-bit Windows 7 on "g"</dt>
+ <dt class="fail">Opera 12, 64-bit Ubuntu Linux 14.04 shows accesskey as "(null)"</dt>
  <dt class="fail">Internet Explorer 11, 64-bit Windows 7 on "g"</dt>
  <dt class="fail">Chrome 46, 64-bit Windows 7 on "g"</dt>
  <dt class="fail">Firefox 42, MacOS 10.10.5</dt>

--- a/tests/accesskey-cyrillic-manual.html
+++ b/tests/accesskey-cyrillic-manual.html
@@ -34,6 +34,7 @@
 <dl>
  <dt class="fail">Vivaldi 1.0.303.52 beta, MacOS 10.10.5 (based on Chromium)</dt>
   <dd class="fail">With a cyrillic keyboard, standard <code>accesskey</code> modifiers plus "я" does not do anything.</dd>
+ <dt class="fail">Opera 12, 64-bit Ubuntu Linux 14.04 shows accesskey as "(null)"</dt>
  <dt class="pass">Firefox 42, MacOS 10.10.5</dt>
   <dd class="pass">ctrl-alt-"я" presses the button, opening the github page</dd>
   <dd class="pass">Firefox exposes "<samp>^⌥я</samp>" as a value of the <code>accessKeyLabel</code> DOM attribute</dd>

--- a/tests/accesskey-duplicate-key-manual.html
+++ b/tests/accesskey-duplicate-key-manual.html
@@ -44,6 +44,7 @@
  <dt class="good">Firefox 42, MacOS 10.10.5</dt>
   <dd class="good">Apparently moves successively focuses each element with the same <code>accesskey</code> value.</dd>
   <dd class="good">Firefox provides "⌃⌥a" as a value for the <code>accessKeyLabel</code> DOM attribute.</dd>
+ <dt class="something">Opera 12, 64-bit Ubuntu Linux 14.04 shows accesskey as "(A) Play Github!" (but first link only)</dt>
  <dt class="good">Firefox 42, 64-bit Ubuntu Linux 14.04</dt>
   <dd class="good">Apparently moves successively focuses each element with the same <code>accesskey</code> value.</dd>
   <dd class="good">Firefox provides "alt+shift+a" as a value for the <code>accessKeyLabel</code> DOM attribute.</dd>

--- a/tests/accesskey-reflected-manual.html
+++ b/tests/accesskey-reflected-manual.html
@@ -50,6 +50,7 @@ function updateInfo() {
 <dl>
  <dt class="partial">Vivaldi 1.0.303.52 beta, MacOS 10.10.5 (based on Chromium)</dt>
   <dd class="fail">Trying to use either key plus modifiers does not do anything.</dd>
+ <dt class="pass">Opera 12, 64-bit Ubuntu Linux 14.04 shows accesskey as "(A) (null)" then "(G) (null)"</dt>
   <dd class="pass">After the timeout, the paragraph below the button gives "<samp>g</samp>" for the value of the <code>accesskey</code>, showing that the DOM <code>accessKey</code> has been successfully updated.</dd>
  <dt class="pass">Firefox 42, MacOS 10.10.5</dt>
   <dd class="pass">Within the first 10 seconds of loading, ctrl-alt-"a" presses the button, opening the github page. Afterward, ctrl-alt-g does so instead.</dd>

--- a/tests/accesskey-two-latin-manual.html
+++ b/tests/accesskey-two-latin-manual.html
@@ -43,6 +43,7 @@
   <dd class="something">Firefox provides "Alt+Shift+a g" as a value for the <code>accessKeyLabel</code> DOM attribute.</dd>
  <dt class="fail">Firefox 42, 64-bit Windows 7</dt>
   <dd class="something">Firefox provides "Alt+Shift+a g" as a value for the <code>accessKeyLabel</code> DOM attribute.</dd>
+ <dt class="fail">Opera 12, 64-bit Ubuntu Linux 14.04 shows accesskey as "("</dt>
  <dt class="pass">Internet Explorer 11, 64-bit Windows 7</dt>
   <dd class="pass">Alt+a moves focus to the button, while Alt+g does nothing.</dd>
  <dt class="fail">Chrome 46, 64-bit Windows 7</dt>

--- a/tests/accesskey-word-manual.html
+++ b/tests/accesskey-word-manual.html
@@ -38,6 +38,7 @@
   <dd class="something">Firefox exposes "<samp>Alt+Shift+word</samp>" as a value of the <code>accessKeyLabel</code> DOM attribute, but it seems not to enable any shortcut.</dd>
  <dt class="something">Firefox 42, 64-bit Windows 7</dt>
   <dd class="something">Firefox exposes "<samp>Alt+Shift+word</samp>" as a value of the <code>accessKeyLabel</code> DOM attribute, but it seems not to enable any shortcut.</dd>
+ <dt class="fail">Opera 12, 64-bit Ubuntu Linux 14.04 shows accesskey as "(null)"</dt>
  <dt class="something">Internet Explorer 11, 64-bit Windows 7</dt>
   <dd class="something">Presses the button with alt+w, though not with alt+o, r or d (some of these are already taken in IE to do other tasks anyway).</dd>
  <dt class="nothing">Chromium 45, 64-bit Ubuntu Linux 14.04</dt>

--- a/tests/accesskeylabel-manual.html
+++ b/tests/accesskeylabel-manual.html
@@ -46,6 +46,7 @@
   <dd class="partial">The button has the text <samp>Play Github! activation: Alt+Shift+話 я g</samp></dd>
   <dd class="partial">When navigating to button, NVDA announces "<samp>button Alt + Shift + Chinese letter</samp>" and then the button text as listed above. It does not mention the other two options.</dd>
   <dd class="fail">Since I cannot generate the 話 or я characters, I cannot find out if those accesskeys work. "g" does not work.</dd>
+ <dt class="fail">Opera 12, 64-bit Ubuntu Linux 14.04, accesskey is "(null)"</dt>
  <dt class="fail">Internet Explorer 11, 64-bit Windows 7 with NVDA</dt>
   <dd class="partial">When navigating to button, NVDA announces "<samp>button Alt + Chinese letter ya g</samp>" and then the button text "Play Github!"</dd>
   <dd class="fail">Since I cannot generate the 話 or я characters, I cannot find out if those accesskeys work. "g" does not.</dd>


### PR DESCRIPTION
Just stating what the access key says when hitting Shift+Esc. If it showed a letter, I could invoke it.
On the duplicate where it says only one link showed, hitting "G" anyway did not invoke the button that was not on the menu.
