### PR TITLE
updated Opera12 results

### DIFF
--- a/tests/accesskey-cyrillic-latin-link-manual.html
+++ b/tests/accesskey-cyrillic-latin-link-manual.html
@@ -58,7 +58,7 @@
     <dd>With a cyrillic keyboard set, none of these browsers enables accesskey using their standard modifiers plus "я"</dd>
  <dt class="something">Opera 12, 64-bit Ubuntu Linux 14.04</dt>
    <dd class="fail">shows accesskey as "("</dd>
-   <dd class="pass">Pressing <kbd>return</kbd> it is possible to activate the single shortcut in the menu</dd>
+   <dd class="partial">Only possible to activate shortcut menu via mouse</dd>
   <dt class="pass">All tested user agents reflect the content of the HTML attribute in the DOM attribute <code>accessKey</code></dd>
 </dl>
 

--- a/tests/accesskey-cyrillic-latin-manual.html
+++ b/tests/accesskey-cyrillic-latin-manual.html
@@ -47,9 +47,9 @@
  <dt class="fail">Chromium 45, 64-bit Ubuntu Linux 14.04 on "g"</dt>
  <dt class="fail">Firefox 42, 64-bit Windows 7 on "g"</dt>
  <dt class="fail">Opera 12, 64-bit Ubuntu Linux 14.04 shows accesskey as "(null)"</dt>
+  <dd class="something">Shortcut can be activated from accesskey menu with mouse</dd>
  <dt class="fail">Internet Explorer 11, 64-bit Windows 7 on "g"</dt>
  <dt class="fail">Chrome 46, 64-bit Windows 7 on "g"</dt>
-
  <dt class="fail">Safari 9.01, VoiceOver on MacOS 10.10.5</dt>
  <dt class="fail">Safari 9.01, MacOS 10.10.5</dt>
  <dt class="fail">Vivaldi 1.0.303.52 beta, MacOS 10.10.5 (based on Chromium)</dt>

--- a/tests/accesskey-cyrillic-manual.html
+++ b/tests/accesskey-cyrillic-manual.html
@@ -36,7 +36,7 @@
   <dd class="fail">With a cyrillic keyboard, standard <code>accesskey</code> modifiers plus "я" does not do anything.</dd>
  <dt class="something">Opera 12, 64-bit Ubuntu Linux 14.04</dt>
   <dd class="fail">shows accesskey as "(null)"</dd>
-  <dd class="something">The single entry in the accesskey menu can be activated by clicking with a mouse or pressing <kbd>return</kbd></dd>
+  <dd class="something">Shortcut can be activated in the accesskey menu with a mouse</dd>
  <dt class="pass">Firefox 42, MacOS 10.10.5</dt>
   <dd class="pass">ctrl-alt-"я" presses the button, opening the github page</dd>
   <dd class="pass">Firefox exposes "<samp>^⌥я</samp>" as a value of the <code>accessKeyLabel</code> DOM attribute</dd>

--- a/tests/accesskey-duplicate-key-manual.html
+++ b/tests/accesskey-duplicate-key-manual.html
@@ -44,18 +44,15 @@
   <dt class="fail">Chrome 46.0.2490.86 m, Windows 7</dt>
 
   <dt class="good">Internet Explorer 11, 64-bit Windows 7</dt>
-   <dd class="good">Apparently moves successively focuses each element with the same <code>accesskey</code> value.</dd>
-
+   <dd class="good">Successively focuses each element with the same <code>accesskey</code> value</dd>
   <dt class="good">Firefox 42, MacOS 10.10.5</dt>
   <dt class="good">Firefox 42, 64-bit Ubuntu Linux 14.04</dt>
   <dt class="good">FireFox 42, Windows 7</dt>
   <dt class="good">Firefox 42, 64-bit Windows 7</dt>
     <dd class="good">Apparently moves successively focuses each element with the same <code>accesskey</code> value.</dd>
     <dd class="good">Firefox provides "⌃⌥a" (Mac) or "alt+shift+a" (windows/linux) as a value for the <code>accessKeyLabel</code> DOM attribute.</dd>
-
   <dt class="something">Opera 12, 64-bit Ubuntu Linux 14.04</dt>
-    <dd>shows accesskey as "(A) Play Github!" (but first link only)</dd>
-
+    <dd>Shows accesskey as "(A) Play Github!" (but first link only)</dd>
   <dt class="something">Epiphany 3.10.3, 64-bit Ubuntu Linux 14.04</dt>
   <dt class="something">Chromium 45, 64-bit Ubuntu Linux 14.04</dt>
   <dt class="something">Chrome 46, 64-bit Windows 7</dt>

--- a/tests/accesskey-multiple-keys.html
+++ b/tests/accesskey-multiple-keys.html
@@ -40,9 +40,9 @@
 
 <dl>
  <dt>Opera 12 (Presto) on 64-bit Ubuntu Linux 14.04</dt>
-   <dd class="pass">all three shortcuts are presented in a menu upon Shift+Esc. Arrow keys don't affect the menu, nor does the Enter key (when there is only 1 accesskey, Enter will engage the button). Typing the character listed as the accesskey invokes it.</dd>
+   <dd class="pass">all three shortcuts are presented in a menu upon Shift+Esc. Typing the character listed as the accesskey invokes it.</dd>
    <dd class="pass">The DOM attribute <code>accessKey</code> is supported</dd>
-   <dd>Does Opera implement <code>accessKeyLabel</code>?</dd>
+   <dd>Does Opera implement <code>accessKeyLabel</code>?</dd><dd>I believe <code>accessKeyLabel</code> is what the accesskey menu is showing, yes</dd>
  <dt class="partial">Yandex browser 15.4.2272.3909 beta, MacOS 10.10.5</dt>
    <dd class="something">The modifiers <kbd>ctrl-alt</kbd> with the relevant key attempts to open the links, but the pop-up blocker stops them opening as if this were not triggered by a user action. The focus is not moved to the relevant link.</dd>
    <dd class="pass">The DOM attribute <code>accessKey</code> is supported</dd>
@@ -56,6 +56,10 @@
    <dd class="pass">The DOM attributes <code>accessKey</code> and <code>accessKeyLabel</code> are supported</dd>
  <dt class="fail">Vivaldi 1.0.303.52 Beta, MacOS 10.10.5</dt>
    <dd class="fail">There is apparently no shortcut that activates the links</dd>
+   <dd class="pass">The DOM attribute <code>accessKey</code> is supported</dd>
+   <dd class="fail">The DOM attribute <code>accessKeyLabel</code> is not supported</dd>
+ <dt class="pass">IE 11, 64-bit Windows 7</dt>
+   <dd class="pass">The modifier <kbd>alt</kbd> with the relevant key focusses on the links</dd>
    <dd class="pass">The DOM attribute <code>accessKey</code> is supported</dd>
    <dd class="fail">The DOM attribute <code>accessKeyLabel</code> is not supported</dd>
 </dl>

--- a/tests/accesskey-two-latin-manual.html
+++ b/tests/accesskey-two-latin-manual.html
@@ -58,7 +58,7 @@
   <dd class="pass">Alt+a moves focus to the button, while Alt+g does nothing.</dd>
  <dt class="partial">Opera 12, 64-bit Ubuntu Linux 14.04</dt>
   <dd class="fail">shows accesskey as "("</dd>
-  <dd class="pass">Pressing <kbd>return</kbd> in, or clicking on the menu activates the single shortcut</dd>
+  <dd class="something">Clicking on the menu with mouse activates the shortcut</dd>
 </dl>
 
 <h2 id="discussion">Discussion</h2>

--- a/tests/accesskey-word-manual.html
+++ b/tests/accesskey-word-manual.html
@@ -24,7 +24,7 @@
 <h2>Expected result</h2>
 <p>A strict HTML5 implementation will not make a shortcut available for the button. An HTML4 implementation may do so. The button will try to open a window with the Github repo for this test, so you can update the <a href="#results">results section</a> :)</p>
 
-<p><button id="theButton" accesskey="word" onclick="window.open('https://github.com/chaals/accesskey/blob/gh-pages/tests/accesskey-cyrillic-manual.html')">Play Github!</button></p>
+<p><button id="theButton" accesskey="word" onclick="window.open('https://github.com/chaals/accesskey/blob/gh-pages/tests/accesskey-word-manual.html')">Play Github!</button></p>
 
 <p id="accesskeyValue">Value of the accessKey DOM attribute: </p>
 
@@ -39,6 +39,7 @@
  <dt class="something">Firefox 42, 64-bit Windows 7</dt>
   <dd class="something">Firefox exposes "<samp>Alt+Shift+word</samp>" as a value of the <code>accessKeyLabel</code> DOM attribute, but it seems not to enable any shortcut.</dd>
  <dt class="fail">Opera 12, 64-bit Ubuntu Linux 14.04 shows accesskey as "(null)"</dt>
+  <dd class="something">Clicking on the accesskey with a mouse in the menu invokes the shortcut</dd>
  <dt class="something">Internet Explorer 11, 64-bit Windows 7</dt>
   <dd class="something">Presses the button with alt+w, though not with alt+o, r or d (some of these are already taken in IE to do other tasks anyway).</dd>
  <dt class="nothing">Chromium 45, 64-bit Ubuntu Linux 14.04</dt>

--- a/tests/accesskeylabel-manual.html
+++ b/tests/accesskeylabel-manual.html
@@ -47,6 +47,7 @@
   <dd class="partial">When navigating to button, NVDA announces "<samp>button Alt + Shift + Chinese letter</samp>" and then the button text as listed above. It does not mention the other two options.</dd>
   <dd class="fail">Since I cannot generate the 話 or я characters, I cannot find out if those accesskeys work. "g" does not work.</dd>
  <dt class="fail">Opera 12, 64-bit Ubuntu Linux 14.04, accesskey is "(null)"</dt>
+   <dd class="something">Shortcut can be activated with a mouse click on the accesskey menu</dd>
  <dt class="fail">Internet Explorer 11, 64-bit Windows 7 with NVDA</dt>
   <dd class="partial">When navigating to button, NVDA announces "<samp>button Alt + Chinese letter ya g</samp>" and then the button text "Play Github!"</dd>
   <dd class="fail">Since I cannot generate the 話 or я characters, I cannot find out if those accesskeys work. "g" does not.</dd>


### PR DESCRIPTION
I tried to repeat the "hitting enter" tests in Opera 12 as I noticed it not working on Windows. I could not reliably reproduce hitting Enter/Return to engage the shortcut. I believe I may have accidentally gotten focus onto the actual button on those times.

I've also considered it a "partial" success if you could click the "(" or "(null)" menu items with the mouse, since while Opera doesn't seem to know the accesskeyLabel in those cases, it does let you click on the menu to invoke it. However keyboard cannot reach it.

It appears the accesskeyLabel is being presented in () first and then sometimes button text following in () or, in the multiple accesskeys pages, the URLs.

I'm curious about the IE/Windows7 failing for someone else on accesskey-duplicate-key-manual.html Yes, it doesn't invoke the shortcuts, but it allows focus around them and hitting Enter then selects it. I would consider this a real shortcut similar to Firefox' solution to multiple identical accesskeys.
